### PR TITLE
Custom resolver

### DIFF
--- a/hooks/hiero_resolve_custom_strings.py
+++ b/hooks/hiero_resolve_custom_strings.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2014 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from tank import Hook
+
+
+class HieroResolveCustomStrings(Hook):
+    """Translates a keyword string into its resolved value for a given task."""
+    # cache of shots that have already been pulled from shotgun
+    _sg_lookup_cache = {}
+
+    def execute(self, task, keyword, **kwargs):
+        """
+        The default implementation of the custom resolver simply looks up
+        the keyword from the shotgun shot dictionary.
+
+        For example, to pull the shot code, you would simply specify 'code'.
+        To pull the sequence code you would use 'sg_sequence.Sequence.code'.
+        """
+        shot_code = task._item.name()
+
+        # grab the shot from the cache, or from Shotgun if it is not cached
+        sg_shot = self._sg_lookup_cache.get(shot_code)
+        if sg_shot is None:
+            fields = [ctf['keyword'] for ctf in self.parent.get_setting('custom_template_fields')]
+            sg_shot = self.parent.shotgun.find_one(
+                "Shot",
+                [['code', 'is', shot_code], ['project', 'is', self.parent.context.project]],
+                fields,
+            )
+
+            self._sg_lookup_cache[shot_code] = sg_shot
+
+        if sg_shot is None:
+            raise RuntimeError("Could not find shot for custom resolver: %s" % shot_code)
+
+        # strip off the leading and trailing curly brackets
+        keyword = keyword[1:-1]
+        result = sg_shot.get(keyword, '')
+
+        self.parent.log_debug("Custom resolver: %s[%s] -> %s" % (shot_code, keyword, result))
+
+        return result

--- a/info.yml
+++ b/info.yml
@@ -34,6 +34,18 @@ configuration:
                 name: { type: str }
         description:
 
+    custom_template_fields:
+      type: list
+      description: "A list of custom strings to add to Hiero's resolver.
+                   Each item needs to be translated to a resolved string
+                   by the resolve custom strings hook."
+      allows_empty: True
+      values:
+        type: dict
+        items:
+            keyword: { type: str }
+            description: { type: str }
+      default_value: []
 
     # hooks
     hook_translate_template:
@@ -74,6 +86,17 @@ configuration:
                      the shot via the sg_sequence field."
         parameters: [item, data]
         default_value: hiero_get_shot
+
+    hook_resolve_custom_strings:
+        type: hook
+        description: "Called when resolving custom items added to the Hiero resolver
+                      via the custom_template_fields setting.  The first argument is
+                      the keyword being resolved and the second argument is the Hiero
+                      task being run.
+
+                      The return value is the resolved string value for the keyword."
+        parameters: [keyword, task]
+        default_value: hiero_resolve_custom_strings
 
     # paths
     template_plate_path:

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -265,3 +265,12 @@ class ShotgunShotProcessorPreset(ShotgunHieroObjectBase, FnShotProcessor.ShotPro
         self.app.log_debug('Adding custom resolver tk_version')
         resolver.addResolver("{tk_version}", "Version string formatted by Shotgun Toolkit.", 
                              lambda keyword, task: self._formatTkVersionString(task.versionString()))
+
+        custom_template_fields = self.app.get_setting("custom_template_fields")
+        self.app.log_debug('Adding custom resolvers %s' % [ctf['keyword'] for ctf in custom_template_fields])
+        for ctf in custom_template_fields:
+            resolver.addResolver(
+                "{%s}" % ctf['keyword'], ctf['description'],
+                lambda keyword, task:
+                    self.app.execute_hook("hook_resolve_custom_strings", keyword=keyword, task=task)
+            )


### PR DESCRIPTION
Added functionality to have a custom resolver hook.

Two config fields were added to tk-hiero-export's config

 custom_resolve_strings: []
hook_resolve_custom_strings: default
