### PR TITLE
Ticket #24838 - Added ability to associate publishes and versions with a task

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -47,6 +47,21 @@ configuration:
             description: { type: str }
       default_value: []
 
+    default_task_filter:
+        type: str
+        description: "A filter that will return the task in the Shot that publishes will
+                     be registered against.  This value must be a valid filter that can be
+                     passed to the find method of the Shotgun api, without a condition for
+                     entity (a value linking entity to the Shot will be added at publish
+                     time).  If the filter contains a condition in the form
+                     ['step.Step.code', 'is', VALUE], then whatver VALUE is will be used
+                     by the default translate_template hook as the value to use when
+                     expanding {Step} in the publish templates.  If the filter results
+                     in a single task, then any publishes created by the app will be
+                     associated with that task.  Otherwise they will only be associated
+                     with the Shot."
+        default_value: "[['step.Step.code', 'is', 'Comp']]"
+
     # hooks
     hook_translate_template:
         type: hook


### PR DESCRIPTION
This adds a new setting that is a string which will be turned into a filter for a shotgun query.  A string is used since lists in the settings files can't have different value types, and I wanted to allow for the values in the filter to be either strings, entities, or ints.

This was needed to allow the published Nuke file to be a valid sgtk publish, since the context that is used can be a task context (specifying the Step param) but the publishes didn't have a valid task before this.
