### PR TITLE
For #25116 Renamed channel to output in Write Node placeholder metadata.

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -24,7 +24,7 @@ configuration:
         description: "A list of dictionaries in which you define the Sgtk write
                      nodes that will be added to the published nuke scripts.
                      Each dictionary entry needs to have the following keys:
-                     channel - the value for the channel knob in the created node.
+                     channel - the value for the 'output' knob in the created node.
                      name - the profile name of the write node to create."
         allows_empty: True
         values:

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -169,8 +169,8 @@ class ShotgunNukeShotExporter(ShotgunHieroObjectBase, FnNukeShotExporter.NukeSho
         FnNukeShotExporter.NukeShotExporter._beforeNukeScriptWrite(self, script)
 
         for toolkit_specifier in self._preset.properties()["toolkitWriteNodes"]:
-            # break down a string like 'Toolkit Node: Mono Dpx ("editorial")' into name and channel
-            match = re.match("^Toolkit Node: (?P<name>.+) \(\"(?P<channel>.+)\"\)",
+            # break down a string like 'Toolkit Node: Mono Dpx ("editorial")' into name and output
+            match = re.match("^Toolkit Node: (?P<name>.+) \(\"(?P<output>.+)\"\)",
                 toolkit_specifier)
 
             metadata = match.groupdict()


### PR DESCRIPTION
Note that the setting in the app manifest is still 'channel' as changing this would require a nasty migration!
