### PR TITLE
#26301: [hiero] way to reset a global cache per-export

### DIFF
--- a/hooks/hiero_pre_export.py
+++ b/hooks/hiero_pre_export.py
@@ -11,7 +11,7 @@
 from sgtk import Hook
 
 
-class HieroPreShotProcessor(Hook):
+class HieroPreExport(Hook):
     """
     Allows clearing of caches prior to shot processing
     """

--- a/info.yml
+++ b/info.yml
@@ -111,12 +111,12 @@ configuration:
         parameters: [item, data]
         default_value: hiero_get_shot
 
-    hook_pre_shot_processor:
+    hook_pre_export:
         type: hook
         description: "Called prior to starting shotgun's shot processor. It can be used
                       to clear out caches and do other specific initializations."
         parameters: [processor]
-        default_value: hiero_pre_shot_processor
+        default_value: hiero_pre_export
 
     hook_resolve_custom_strings:
         type: hook

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -34,7 +34,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
 
         # Call pre processor hook here to make sure it happens pior to any 'hook_resolve_custom_strings'.
         # The order if execution is basically [init processor, resolve user entries, startProcessing].
-        self.app.execute_hook("hook_pre_shot_processor", processor=self)
+        self.app.execute_hook("hook_pre_export", processor=self)
 
     def displayName(self):
         return "Shotgun Shot Processor"


### PR DESCRIPTION
The resolve hook is called tons during an export, so expensive resolve results need to be cached. There currently isn't a hook available that run pre-export where that cache could be cleared
