### PR TITLE
#35198: Log metrics for apps launched outside of registered command framework

### DIFF
--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -173,7 +173,7 @@ class ShotgunAudioExporter(ShotgunHieroObjectBase, FnAudioExportTask.AudioExport
 
         # Log usage metrics
         try:
-            self.app.log_metric("Create")
+            self.app.log_metric("Audio Export")
             self.app.engine.log_user_attribute_metric(
                 "%s version" % (self.app.name,),
                 self.app.version,

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -173,11 +173,7 @@ class ShotgunAudioExporter(ShotgunHieroObjectBase, FnAudioExportTask.AudioExport
 
         # Log usage metrics
         try:
-            self.app.log_metric("Audio Export")
-            self.app.engine.log_user_attribute_metric(
-                "%s version" % (self.app.name,),
-                self.app.version,
-            )
+            self.app.log_metric("Audio Export", log_version=True)
         except:
             # ingore any errors. ex: metrics logging not supported
             pass

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -171,6 +171,17 @@ class ShotgunAudioExporter(ShotgunHieroObjectBase, FnAudioExportTask.AudioExport
         if self._do_publish:
             self._publish()
 
+        # Log usage metrics
+        try:
+            self.app.log_metric("Create")
+            self.app.engine.log_user_attribute_metric(
+                "%s version" % (self.app.name,),
+                self.app.version,
+            )
+        except:
+            # ingore any errors. ex: metrics logging not supported
+            pass
+
     def _publish(self):
         """
         Publish task output.

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -180,11 +180,7 @@ class ShotgunNukeShotExporter(ShotgunHieroObjectBase, FnNukeShotExporter.NukeSho
 
         # Log usage metrics
         try:
-            self.app.log_metric("Shot Export")
-            self.app.engine.log_user_attribute_metric(
-                "%s version" % (self.app.name,),
-                self.app.version,
-            )
+            self.app.log_metric("Shot Export", log_version=True)
         except:
             # ingore any errors. ex: metrics logging not supported
             pass

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -178,6 +178,17 @@ class ShotgunNukeShotExporter(ShotgunHieroObjectBase, FnNukeShotExporter.NukeSho
         # upload thumbnail for sequence
         self._upload_thumbnail_to_sg(sg_publish, self._thumbnail)
 
+        # Log usage metrics
+        try:
+            self.app.log_metric("Create")
+            self.app.engine.log_user_attribute_metric(
+                "%s version" % (self.app.name,),
+                self.app.version,
+            )
+        except:
+            # ingore any errors. ex: metrics logging not supported
+            pass
+
     def _beforeNukeScriptWrite(self, script):
         """
         Add ShotgunWriteNodePlaceholder Metadata nodes for tk-nuke-writenode to 

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -180,7 +180,7 @@ class ShotgunNukeShotExporter(ShotgunHieroObjectBase, FnNukeShotExporter.NukeSho
 
         # Log usage metrics
         try:
-            self.app.log_metric("Create")
+            self.app.log_metric("Shot Export")
             self.app.engine.log_user_attribute_metric(
                 "%s version" % (self.app.name,),
                 self.app.version,

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -358,7 +358,7 @@ class ShotgunTranscodeExporter(ShotgunHieroObjectBase, FnTranscodeExporter.Trans
 
         # Log usage metrics
         try:
-            self.app.log_metric("Create")
+            self.app.log_metric("Version Create")
             self.app.engine.log_user_attribute_metric(
                 "%s version" % (self.app.name,),
                 self.app.version,

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -356,6 +356,17 @@ class ShotgunTranscodeExporter(ShotgunHieroObjectBase, FnTranscodeExporter.Trans
             version_data=vers,
         )
 
+        # Log usage metrics
+        try:
+            self.app.log_metric("Create")
+            self.app.engine.log_user_attribute_metric(
+                "%s version" % (self.app.name,),
+                self.app.version,
+            )
+        except:
+            # ingore any errors. ex: metrics logging not supported
+            pass
+
 
 class ShotgunTranscodePreset(ShotgunHieroObjectBase, FnTranscodeExporter.TranscodePreset, CollatedShotPreset):
     """ Settings for the shotgun transcode step """

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -358,11 +358,7 @@ class ShotgunTranscodeExporter(ShotgunHieroObjectBase, FnTranscodeExporter.Trans
 
         # Log usage metrics
         try:
-            self.app.log_metric("Version Create")
-            self.app.engine.log_user_attribute_metric(
-                "%s version" % (self.app.name,),
-                self.app.version,
-            )
+            self.app.log_metric("Version Create", log_version=True)
         except:
             # ingore any errors. ex: metrics logging not supported
             pass

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -358,7 +358,7 @@ class ShotgunTranscodeExporter(ShotgunHieroObjectBase, FnTranscodeExporter.Trans
 
         # Log usage metrics
         try:
-            self.app.log_metric("Version Create", log_version=True)
+            self.app.log_metric("Transcode & Publish", log_version=True)
         except:
             # ingore any errors. ex: metrics logging not supported
             pass


### PR DESCRIPTION
This change logs the app version and action metrics for the various export types.