### PR TITLE
For #35432 handle intermittent Windows issue removing temp thumbnail

### DIFF
--- a/hooks/hiero_upload_thumbnail.py
+++ b/hooks/hiero_upload_thumbnail.py
@@ -14,6 +14,7 @@ import math
 import shutil
 import tempfile
 import traceback
+import time
 
 from PySide import QtCore
 
@@ -62,4 +63,12 @@ class HieroUploadThumbnail(Hook):
             tb = traceback.format_exc()
             self.parent.log_debug(tb)
         finally:
-            shutil.rmtree(thumbdir)
+            # Sometimes Windows holds on to the temporary thumbnail file longer than expected which
+            # can cause an exception here. If we wait a second and try again, this usually solves
+            # the issue.
+            try:
+                shutil.rmtree(thumbdir)
+            except:
+                self.parent.log_error("Error removing temporary thumbnail file, trying again.")
+                time.sleep(1.0)
+                shutil.rmtree(thumbdir)

--- a/hooks/hiero_upload_thumbnail.py
+++ b/hooks/hiero_upload_thumbnail.py
@@ -68,7 +68,7 @@ class HieroUploadThumbnail(Hook):
             # the issue.
             try:
                 shutil.rmtree(thumbdir)
-            except:
+            except Exception:
                 self.parent.log_error("Error removing temporary thumbnail file, trying again.")
                 time.sleep(1.0)
                 shutil.rmtree(thumbdir)

--- a/python/tk_hiero_export/base.py
+++ b/python/tk_hiero_export/base.py
@@ -72,7 +72,7 @@ class ShotgunHieroObjectBase(object):
             # the issue.
             try:
                 shutil.rmtree(thumbdir)
-            except:
+            except Exception:
                 self.parent.log_error("Error removing temporary thumbnail file, trying again.")
                 time.sleep(1.0)
                 shutil.rmtree(thumbdir)

--- a/python/tk_hiero_export/base.py
+++ b/python/tk_hiero_export/base.py
@@ -11,6 +11,7 @@
 import os
 import sys
 import shutil
+import time
 
 from PySide import QtGui
 from PySide import QtCore
@@ -66,8 +67,15 @@ class ShotgunHieroObjectBase(object):
         except Exception, e:
             self.app.log_info("Thumbnail for %s %s (#%s) was not refreshed in Shotgun: %s" % (sg_entity['type'], sg_entity.get('name'), sg_entity['id'], e))
         finally:
-            shutil.rmtree(thumbdir)
-
+            # Sometimes Windows holds on to the temporary thumbnail file longer than expected which
+            # can cause an exception here. If we wait a second and try again, this usually solves
+            # the issue.
+            try:
+                shutil.rmtree(thumbdir)
+            except:
+                self.parent.log_error("Error removing temporary thumbnail file, trying again.")
+                time.sleep(1.0)
+                shutil.rmtree(thumbdir)
 
 
 


### PR DESCRIPTION
Windows occasionally holds on to the temporary thumbnail file longer than it needs to which can cause an error when we try and remove it after uploading it to Shotgun: 

```
[Error 32] The process cannot access the file because it is being used by another process
``` 
This fix catches the error and waits 1 second for the process to let go of the file before trying again. If for some reason the file still cannot be removed, we raise the exception.