### PR TITLE
#38124 Attempting to identify hiero changes that cause collate not to work

### DIFF
--- a/python/tk_hiero_export/collating_exporter.py
+++ b/python/tk_hiero_export/collating_exporter.py
@@ -154,7 +154,7 @@ class CollatingExporter(object):
             # This flag indicates that an explicit start frame has been specified
             # To make sure that when the shot is expanded to include handles this is still the first
             # frame, here we offset the start frame by the in-handle size
-            if properties["collateCustomStart"]:
+            if properties["collateCustomStart"] and self._cutHandles is not None:
                 self._startFrame += self._cutHandles
 
             # The offset required to shift the timeline position to the custom start frame.
@@ -182,7 +182,7 @@ class CollatingExporter(object):
                 for tag in parentTrack.tags():
                     trackClone.addTag(hiero.core.Tag(tag))
 
-            trackItemClone = trackitem.clone()
+            trackItemClone = trackitem.copy()
             self._collatedItemsMap[trackitem.guid()] = trackItemClone
             
             # Copy audio for track item
@@ -201,7 +201,7 @@ class CollatingExporter(object):
                         for tag in audioParentTrack.tags():
                             audioTrackClone.addTag(hiero.core.Tag(tag))
                     
-                    audioItemClone = item.clone()
+                    audioItemClone = item.copy()
                     trackItemClone.link(audioItemClone)
 
                     self._collatedItemsMap[item.guid()] = audioItemClone
@@ -259,7 +259,7 @@ class CollatingExporter(object):
         self._parentSequence = self._sequence
 
         # Need to use the sequence clone here, otherwise audio becomes silent for unknown reasons.
-        self._sequence = newSequence.clone()
+        self._sequence = newSequence.copy()
 
     def isCollated(self):
         return self._collate

--- a/python/tk_hiero_export/collating_exporter.py
+++ b/python/tk_hiero_export/collating_exporter.py
@@ -321,7 +321,7 @@ class CollatingExporter(object):
 
 def _clone_item(item):
     """
-    Older versions of hiero use clone() but its deprecated in nukestudio in
+    Older versions of hiero use clone() but it's deprecated in nukestudio in
     favor of copy().
 
     Use the appropriate method to clone the item.

--- a/python/tk_hiero_export/collating_exporter.py
+++ b/python/tk_hiero_export/collating_exporter.py
@@ -182,7 +182,7 @@ class CollatingExporter(object):
                 for tag in parentTrack.tags():
                     trackClone.addTag(hiero.core.Tag(tag))
 
-            trackItemClone = trackitem.copy()
+            trackItemClone = _clone_item(trackitem)
             self._collatedItemsMap[trackitem.guid()] = trackItemClone
             
             # Copy audio for track item
@@ -201,7 +201,7 @@ class CollatingExporter(object):
                         for tag in audioParentTrack.tags():
                             audioTrackClone.addTag(hiero.core.Tag(tag))
                     
-                    audioItemClone = item.copy()
+                    audioItemClone = _clone_item(item)
                     trackItemClone.link(audioItemClone)
 
                     self._collatedItemsMap[item.guid()] = audioItemClone
@@ -259,7 +259,7 @@ class CollatingExporter(object):
         self._parentSequence = self._sequence
 
         # Need to use the sequence clone here, otherwise audio becomes silent for unknown reasons.
-        self._sequence = newSequence.copy()
+        self._sequence = _clone_item(newSequence)
 
     def isCollated(self):
         return self._collate
@@ -317,6 +317,20 @@ class CollatingExporter(object):
                 start = self._startFrame
 
         return (start, end)
+
+
+def _clone_item(item):
+    """
+    Older versions of hiero use clone() but its deprecated in nukestudio in
+    favor of copy().
+
+    Use the appropriate method to clone the item.
+    """
+
+    if hasattr(item, "copy"):
+        return item.copy()
+    else:
+        return item.clone()
 
 
 class CollatedShotPreset(object):

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -185,6 +185,24 @@ class ShotgunNukeShotExporter(ShotgunHieroObjectBase, FnNukeShotExporter.NukeSho
             # ingore any errors. ex: metrics logging not supported
             pass
 
+    def isExportingItem(self, item):
+        """
+        This method overrides the default method added to the base class in
+        Nuke 10. The base class returns ``True`` for all items found in the
+        list of collated items. This prevents unnecessary exports for those items
+        since non-SG workflows only collate into the exported nuke script of the
+        first exported track item. For SG workflows, we still export versions
+        for collated tracks and link them back to the hero shot. So we need to
+        do our own culling of tasks in the shot processor. So we return ``False``
+        unless the item is the current item.
+        """
+
+        # Return true if this is the main item for this task, or it's in the list of collated items.
+        if item == self._item:
+            return True
+        else:
+            return False
+
     def _beforeNukeScriptWrite(self, script):
         """
         Add ShotgunWriteNodePlaceholder Metadata nodes for tk-nuke-writenode to 

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -324,16 +324,12 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         # iterate over the tasks groups to be executed
         for taskGroup in self._submission.children():
 
-            print "TASK GROUP: " + str(taskGroup)
-
             # placeholders for the tasks we want to pre-process
             (shot_updater_task, transcode_task) = (None, None)
 
             # look at all the tasks in the group and identify the shot updater
             # and transcode tasks.
             for task in taskGroup.children():
-
-                print "  TASK: " + str(task)
 
                 # shot updater
                 if isinstance(task, ShotgunShotUpdater):

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -324,12 +324,16 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         # iterate over the tasks groups to be executed
         for taskGroup in self._submission.children():
 
+            print "TASK GROUP: " + str(taskGroup)
+
             # placeholders for the tasks we want to pre-process
             (shot_updater_task, transcode_task) = (None, None)
 
             # look at all the tasks in the group and identify the shot updater
             # and transcode tasks.
             for task in taskGroup.children():
+
+                print "  TASK: " + str(task)
 
                 # shot updater
                 if isinstance(task, ShotgunShotUpdater):


### PR DESCRIPTION
The primary fix here is to account for changes in behavior in Hiero 10 with respect for collating shots.

An additional backward compatibility fix is added that changes use the newer `item.copy()` if possible, else fallback to the deprecated `item.clone()`. This eliminates deprecation warnings in the script editor in hiero/nuke.

Also ensures `_cutHandles` is defined when collating with `Clip Length` export option selected.