### PR TITLE
#38789 Apply custom start frame to cut item in/out. Set Version frame fields

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -212,7 +212,7 @@ requires_shotgun_fields:
 
 # More verbose description of this item
 display_name: "Shotgun Export"
-description: "App that adds Shotgun awareness to Hiero's sequence export.  It
+description: "App that adds Shotgun awareness to Nuke Studio's sequence export.  It
              adds a new processor that will use the configuration to determine
              paths for Nuke scripts and plates.  It also will use the tags to
              determine Shotgun Shot status and task templates to create/update

--- a/python/tk_hiero_export/shot_updater.py
+++ b/python/tk_hiero_export/shot_updater.py
@@ -68,13 +68,8 @@ class ShotgunShotUpdater(ShotgunHieroObjectBase, FnShotExporter.ShotTask, Collat
 
         if self._startFrame is not None:
             # a custom start frame was specified
-            edit_in += self._startFrame
-            edit_out += self._startFrame
-        else:
-            # use the starttime from the hiero sequence
-            seq = self._item.sequence()
-            edit_in += seq.timecodeStart()
-            edit_out += seq.timecodeStart()
+            cut_in += self._startFrame
+            cut_out += self._startFrame
 
         cut_duration = cut_out - cut_in + 1
         edit_duration = edit_out - edit_in + 1
@@ -206,13 +201,8 @@ class ShotgunShotUpdater(ShotgunHieroObjectBase, FnShotExporter.ShotTask, Collat
                 cut_in = head_in + in_handle
                 cut_out = tail_out - out_handle
             else:
+                # the cut in/out should already be correct here. just log
                 self.app.log_debug("Exporting... clip length.")
-                # for clip length exports, the head/tail should already be the
-                # full source range. we just need to account for the custom
-                # start frame to match what Hiero writes to disk.
-                if self._startFrame is not None:
-                    cut_in += self._startFrame
-                    cut_out += self._startFrame
 
         # calculate the duration values now that the ins/outs are set
         cut_duration = cut_out - cut_in + 1

--- a/python/tk_hiero_export/shot_updater.py
+++ b/python/tk_hiero_export/shot_updater.py
@@ -63,8 +63,14 @@ class ShotgunShotUpdater(ShotgunHieroObjectBase, FnShotExporter.ShotTask, Collat
             cut_in = source_in
             cut_out = source_out
 
+        # get the edit in/out points from the timeline
         edit_in = self._item.timelineIn()
         edit_out = self._item.timelineOut()
+
+        # account for custom start code in the hiero timeline
+        seq = self._item.sequence()
+        edit_in += seq.timecodeStart()
+        edit_out += seq.timecodeStart()
 
         if self._startFrame is not None:
             # a custom start frame was specified


### PR DESCRIPTION
These changes fix a couple of isses with the round trip between editorial and comp. The custom start value was being applied to the edit fields on the cut item when it should have been applied to the cut item in/out fields. In addition, the version that was created did not have any values populated for frame start/end. 