### PR TITLE
#38787 Update quicktime encoder defaults for newer NukeStudio versions.

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,6 +75,36 @@ class HieroExport(Application):
         """
         return True
 
+    def get_default_encoder_name(self):
+        """Returns the default encoder for use in quicktime generation.
+
+        The value returned is dependent on the platform and the version of
+        Hiero/NukeStudio being used.
+
+        The "mov32" encoder does not work in newer versions of Hiero/NukeStudio
+        (10.0v2 or greater) where there is no dependency on the Qt desktop
+        application.
+
+        :return: The name of the default encoder to use for this platform
+            and version of Hiero/NukeStudio
+        :rtype: str
+        """
+
+        if sys.platform.startswith("linux"):
+            encoder_name = "mov64"
+        else:
+            encoder_name = "mov32"
+            try:
+                import nuke
+                if nuke.NUKE_VERSION_MAJOR >= 10 and nuke.NUKE_VERSION_RELEASE > 1:
+                    # newer version of nuke without access to desktop Qt
+                    encoder_name = "mov64"
+            except ImportError:
+                # can't import nuke. older version of Hiero
+                pass
+
+        return encoder_name
+
     def _register_exporter(self):
         """
         Set up this app with the hiero exporter frameworks

--- a/hooks/hiero_get_quicktime_settings.py
+++ b/hooks/hiero_get_quicktime_settings.py
@@ -23,6 +23,7 @@ class HieroGetQuicktimeSettings(Hook):
         write node and the second item is a dictionary of knob names and
         values.
         """
+
         if sys.platform.startswith("linux"):
             file_type = "mov"
             properties = {
@@ -33,7 +34,7 @@ class HieroGetQuicktimeSettings(Hook):
         else:
             file_type = "mov"
             properties = {
-                "encoder": "mov32",
+                "encoder": self.parent.get_default_encoder_name(),
                 "codec": "avc1\tH.264",
                 "quality": 3,
                 "settingsString": "H.264, High Quality",

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -102,13 +102,15 @@ class ShotgunTranscodeExporter(ShotgunHieroObjectBase, FnTranscodeExporter.Trans
         Override the default buildScript functionality to also output a temp movie
         file if needed for uploading to Shotgun
         """
+
         # This is a bit of a hack to account for some changes to the
         # transcode exporter that ships with Nuke/Hiero 9.0 compared
         # to earlier versions of Hiero.
         file_type = self._preset.properties()['file_type']
         if file_type in ["mov", "ffmpeg"]:
             if not self._preset.properties()[file_type].get("encoder"):
-                self._preset.properties()[file_type]["encoder"] = "mov32"
+                encoder_name = self.app.get_default_encoder_name()
+                self._preset.properties()[file_type]["encoder"] = encoder_name
 
         # Build the usual script
         FnTranscodeExporter.TranscodeExporter.buildScript(self)
@@ -137,6 +139,7 @@ class ShotgunTranscodeExporter(ShotgunHieroObjectBase, FnTranscodeExporter.Trans
 
         # insert the write node to generate the quicktime
         file_type, properties = self.app.execute_hook("hook_get_quicktime_settings", for_shotgun=True)
+        self.app.log_info("Transcode quicktime settings: %s" % (properties,))
         preset.properties().update({
             "file_type": file_type,
             file_type: properties,


### PR DESCRIPTION
When the user is exporting frames, and we need to generate the quicktime ourselves in the transcode task, we were defaulting to **mov32**. This should be **mov64** for newer versions of NukeStudio (10.0v2+) where there is no dependency on Quicktime (since **mov32** requires Quicktime).