### PR TITLE
#39911 Fixes broken export dialog UI/layout in Hiero 10.5v1

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,6 +105,25 @@ class HieroExport(Application):
 
         return encoder_name
 
+    def get_nuke_version_tuple(self):
+        """
+        Returns a tuple of the nuke version for comparing against using python's
+        handy tuple comparison.
+
+        Usage example::
+
+            # see if the current version is >= Nuke 10.5v1
+            if app.get_nuke_version_tuple() >= (10, 5, 1):
+                ...
+        """
+
+        import nuke
+        return (
+            nuke.NUKE_VERSION_MAJOR,
+            nuke.NUKE_VERSION_MINOR,
+            nuke.NUKE_VERSION_RELEASE
+        )
+
     def _register_exporter(self):
         """
         Set up this app with the hiero exporter frameworks
@@ -199,3 +218,4 @@ class HieroExport(Application):
                             "or adjust the hook that converts a template to a hiero export "
                             "path to convert these fields into fixed strings or hiero "
                             "substitution tokens." % (template_str, ",".join(key_names) ) )
+

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -58,7 +58,29 @@ class ShotgunNukeShotExporterUI(ShotgunHieroObjectBase, FnNukeShotExporterUI.Nuk
         self._toolkit_list.setModel(self._toolkit_model)
         self._toolkit_model.dataChanged.connect(self.toolkitPresetChanged)
 
-        layout.insertRow(0, "Shotgun Write Nodes:", self._toolkit_list)
+        form_layout = None
+
+        # The layout type changed in 10.5v1. Prior to 10.5v1, the widget's
+        # layout was a QFormLayout. Post 10.5v1, the layout is a QVBoxLayout
+        # that contains a form layout where the UI should be inserted.
+        if self.app.get_nuke_version_tuple() >= (10, 5, 1):
+            # QVBoxLayout. Find the QFormLayout within. we'll assume it is the
+            # first one we find.
+            for child in layout.children():
+                if isinstance(child, QtGui.QFormLayout):
+                    # found a form layout
+                    form_layout = child
+                    break
+        else:
+            form_layout = layout
+
+        if form_layout:
+            form_layout.insertRow(0, "Shotgun Write Nodes:", self._toolkit_list)
+        else:
+            self.app.log_error(
+                "Unable to find the expected UI layout to display the list of "
+                "Shotgun Write Nodes in the export dialog."
+            )
 
     def toolkitPresetChanged(self, topLeft, bottomRight):
         self._preset.properties()["toolkitWriteNodes"] = []

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -69,7 +69,7 @@ class ShotgunShotProcessorUI(ShotgunHieroObjectBase, ShotProcessorUI, CollatingE
             (widget, exportItems, editMode) = args
 
         # create a layout with custom top and bottom widgets
-        master_layout = QtGui.QVBoxLayout(widget)
+        master_layout = QtGui.QHBoxLayout(widget)
         master_layout.setContentsMargins(0, 0, 0, 0)
 
         # add group box for shotgun stuff
@@ -79,14 +79,18 @@ class ShotgunShotProcessorUI(ShotgunHieroObjectBase, ShotProcessorUI, CollatingE
 
         # create some helpful text
         header_text = QtGui.QLabel()
-        header_text.setText("""<big>Welcome to the Shotgun Shot Export!</big>
-                      <p>When you are using the Shotgun Shot Processor, Shots and Sequences in<br>
-                      Shotgun will be created based on your Hiero Project. Existing Shots will<br>
-                      be updated with the latest cut lengths. Quicktimes for each shot will be <br>
-                      sent to Screening Room for review when you use the special Shotgun <br>
-                      Transcode plugin - all included and ready to go in the default preset.<br>&nbsp;
-                      </p>
-                      """)
+        header_text.setWordWrap(True)
+        header_text.setText(
+            """
+            <big>Welcome to the Shotgun Shot Export!</big>
+            <p>When you are using the Shotgun Shot Processor, Shots and Sequences in
+            Shotgun will be created based on your Hiero Project. Existing Shots will
+            be updated with the latest cut lengths. Quicktimes for each shot will be
+            sent to Screening Room for review when you use the special Shotgun
+            Transcode plugin - all included and ready to go in the default preset.
+            </p>
+            """
+        )
         shotgun_layout.addWidget(header_text)
 
         # make space for the spreadsheet
@@ -112,6 +116,8 @@ class ShotgunShotProcessorUI(ShotgunHieroObjectBase, ShotProcessorUI, CollatingE
         if self._cutsSupported():
             cut_type_layout = self._build_cut_type_layout(properties)
             shotgun_layout.addLayout(cut_type_layout)
+
+        shotgun_layout.addStretch()
 
         # add default settings from baseclass below
         default = QtGui.QWidget()

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -49,19 +49,20 @@ class ShotgunTranscodeExporterUI(ShotgunHieroObjectBase, FnTranscodeExporterUI.T
         self._preset._properties["create_version"] = create_version
 
     def populateUI(self, widget, exportTemplate):
-        # create a layout with custom top and bottom widgets
-        layout = QtGui.QVBoxLayout(widget)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(9)
+
+        # prior to 10.5v1, this method created the layout. in 10.5v1 and later,
+        # the widget already has a layout
+        if self.app.get_nuke_version_tuple() >= (10, 5, 1):
+            layout = widget.layout()
+        else:
+            # create a layout with custom top and bottom widgets
+            layout = QtGui.QVBoxLayout(widget)
+            layout.setContentsMargins(0, 0, 0, 0)
+            layout.setSpacing(9)
 
         top = QtGui.QWidget()
-        middle = QtGui.QWidget()
-        bottom = QtGui.QWidget()
-        layout.addWidget(top)
-        layout.addWidget(middle)
-        layout.addWidget(bottom)
 
-        top_layout = QtGui.QVBoxLayout(top)
+        top_layout = QtGui.QVBoxLayout()
         top_layout.setContentsMargins(9, 0, 9, 0)
         create_version_checkbox = QtGui.QCheckBox("Create Shotgun Version", widget)
         create_version_checkbox.setToolTip(
@@ -69,17 +70,30 @@ class ShotgunTranscodeExporterUI(ShotgunHieroObjectBase, FnTranscodeExporterUI.T
             "If the output format is not a quicktime, then\n"
             "a quicktime will be created.  The quicktime will\n"
             "be uploaded to Shotgun as Screening Room media."
-            )
+        )
+
         create_version_checkbox.setCheckState(QtCore.Qt.Checked)
         if not self._preset._properties.get("create_version", True):
             create_version_checkbox.setCheckState(QtCore.Qt.Unchecked)
         create_version_checkbox.stateChanged.connect(self.create_version_changed)
         top_layout.addWidget(create_version_checkbox)
 
+        top.setLayout(top_layout)
+
+        middle = QtGui.QWidget()
+
+        # prior to 10.5v1, the layout was set in the base class. in 10.5v1, the
+        # base class expects the widget to already have a layout.
+        if self.app.get_nuke_version_tuple() >= (10, 5, 1):
+            middle.setLayout(QtGui.QVBoxLayout())
+
         # populate the middle with the standard layout
         FnTranscodeExporterUI.TranscodeExporterUI.populateUI(self, middle, exportTemplate)
 
-        layout = QtGui.QVBoxLayout(top)
+        layout.addWidget(top)
+        layout.addWidget(middle)
+
+
 
 
 class ShotgunTranscodeExporter(ShotgunHieroObjectBase, FnTranscodeExporter.TranscodeExporter, CollatingExporter):


### PR DESCRIPTION
There were some changes in the Hiero core APIs that caused our integration to stop working. Since we subclass from these core APIs this is inevitable. These changes adds backward compatible support to allow the export dialog to display widgets appropriately. 

Adds a convenience method to the app to make comparing the current DCC version a bit easier. Also modifies the layout to prevent SG widgets from forcing the export dialog off screen. 