### PR TITLE
SG-4579 Bug Fix for preview Mov creation during export

### DIFF
--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -118,6 +118,11 @@ class ShotgunTranscodeExporter(ShotgunHieroObjectBase, FnTranscodeExporter.Trans
     """
     Create Transcode object and send to Shotgun
     """
+
+    # This is an arbitrarily named label we will use as a SetNode id,
+    # which can then be later used to connect a PushNode to
+    _write_set_node_label = "SG_Write_Attachment"
+
     def __init__(self, initDict):
         """ Constructor """
         FnTranscodeExporter.TranscodeExporter.__init__(self, initDict)
@@ -134,19 +139,11 @@ class ShotgunTranscodeExporter(ShotgunHieroObjectBase, FnTranscodeExporter.Trans
         Override the default addWriteNodeToScript functionality so that we can add a SetNode before
         the default writenodes get added to the script. The SetNode will allow us to later push our mov writenode
         to this point so that it get parented correctly.
-        :param script:
-        :param rootNode:
-        :param framerate:
-        :return:
         """
         self.app.log_debug("Adding SetNode before base write node gets added")
-        # We create and store an arbitrary name for our SetNode, this is used as an id, so that when we create
-        # the PushNode later we can connect it to this SetNode.
-        self.write_set_node_label = "SG_Write_Attachment"
-
         # Add the SetNode before the write nodes are added.
-        setCommand = nuke.SetNode(self.write_set_node_label, 0)
-        script.addNode(setCommand)
+        set_command = nuke.SetNode(self._write_set_node_label, 0)
+        script.addNode(set_command)
 
         super(ShotgunTranscodeExporter, self).addWriteNodeToScript(script, rootNode, framerate)
 
@@ -240,8 +237,8 @@ class ShotgunTranscodeExporter(ShotgunHieroObjectBase, FnTranscodeExporter.Trans
 
         # We create a push node and connect it to the set node we created just before the base write node was created
         # This means that our write node will parent to the same node the base write node gets parented to.
-        pushCommand = nuke.PushNode(self.write_set_node_label)
-        self._script.addNode(pushCommand)
+        push_command = nuke.PushNode(self._write_set_node_label)
+        self._script.addNode(push_command)
 
         self._script.addNode(mov_write_node)
 


### PR DESCRIPTION
There is a bug with the Mov preview/Shotgun upload version behaviour in the Nuke Studio/Hiero export app. If your Shotgun Transcode Job has "Create Shotgun Version" ticket on, and the file type your exporting is not "mov":
<img width="177" alt="Export" src="https://user-images.githubusercontent.com/3777228/55014900-b8510a00-4fe3-11e9-9a23-4e125d0c8e45.png">

Then it won't create a temporary mov that can be uploaded to Shotgun.

The reason for this is that going from NS 10.x to NS 11.x the script NS generates to produce the renders now has a viewer node, which means the SG write node can no longer be automatically connected on the end, which means it becomes detached from the node tree:

NS 10.x (working):
<img width="210" alt="node_attached" src="https://user-images.githubusercontent.com/3777228/55015258-6e1c5880-4fe4-11e9-93bb-672979d12be9.png">
NS 11.x (not working):
<img width="335" alt="node_not_attached" src="https://user-images.githubusercontent.com/3777228/55015297-7c6a7480-4fe4-11e9-97b7-743ab07e36ed.png">
NS 11.x with the fix:
<img width="248" alt="Untitled__modified__-_Nuke" src="https://user-images.githubusercontent.com/3777228/55015430-b0de3080-4fe4-11e9-851b-4434d4dce8a9.png">

The fix is to make use of `SetNode` and `PushNode` to parent our writenode further up the tree. The downside with this fix is that we need to override another method from the base class so that we can insert the `SetNode` before the standard write node gets created, but I don't believe there is any other way around this.