### PR TITLE
Pass task to post_version_creation hook and allow hook based publishing with association to Version.

### DIFF
--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -430,7 +430,7 @@ class ShotgunTranscodeExporter(ShotgunHieroObjectBase, FnTranscodeExporter.Trans
         vers = None
         if self._preset.properties()['create_version']:
             if published_file_entity_type == "PublishedFile":
-                if hasattr(self._version_data, "published_files") and isinstance(self._version_data, list):
+                if "published_files" in self._version_data and isinstance(self._version_data.get('published_files'), list):
                     self._version_data["published_files"] += [pub_data]    
                 else:
                     self._version_data["published_files"] = [pub_data]

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -430,7 +430,10 @@ class ShotgunTranscodeExporter(ShotgunHieroObjectBase, FnTranscodeExporter.Trans
         vers = None
         if self._preset.properties()['create_version']:
             if published_file_entity_type == "PublishedFile":
-                self._version_data["published_files"] = [pub_data]
+                if hasattr(self._version_data, "published_files") and isinstance(self._version_data, list):
+                    self._version_data["published_files"] += [pub_data]    
+                else:
+                    self._version_data["published_files"] = [pub_data]
             else:  # == "TankPublishedFile
                 self._version_data["tank_published_file"] = pub_data
 
@@ -449,6 +452,7 @@ class ShotgunTranscodeExporter(ShotgunHieroObjectBase, FnTranscodeExporter.Trans
             self.app.execute_hook(
                 "hook_post_version_creation",
                 version_data=vers,
+                task=self,
                 base_class=HieroPostVersionCreation,
             )
 


### PR DESCRIPTION
Two things. 
1) Given it's possible to publish other items in hooks prior to creating the version, we should check if the self._version_data['published_files'] attribute has been set and is a list. If it is, then we need to append the main publish, not overwrite any existing items.
2) We may want to do further publishes in the hook_post_version_creation hook based on the item/task being processed. Like the other hooks, we should be passing self as a task argument to this hook to allow for this.