### PR TITLE
SG-11682 Fix for nuke write node linking

### DIFF
--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -268,7 +268,7 @@ class ShotgunNukeShotExporter(ShotgunHieroObjectBase, FnNukeShotExporter.NukeSho
             for toolkit_specifier in self._preset.properties()["toolkitWriteNodes"]:
                 # break down a string like 'Toolkit Node: Mono Dpx ("editorial")' into name and output
                 match = re.match("^Toolkit Node: (?P<name>.+) \(\"(?P<output>.+)\"\)",
-                    toolkit_specifier)
+                                 toolkit_specifier)
 
                 metadata = match.groupdict()
                 node = nuke.MetadataNode(metadatavalues=metadata.items())

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -246,7 +246,7 @@ class ShotgunNukeShotExporter(ShotgunHieroObjectBase, FnNukeShotExporter.NukeSho
 
     def _beforeNukeScriptWrite(self, script):
         """
-        Add ShotgunWriteNodePlaceholder Metadata nodes for tk-nuke-writenode to 
+        AddShotgunWriteNodePlaceholder Metadata nodes for tk-nuke-writenode to
         create full Tk WriteNodes in the Nuke environment
         """
         FnNukeShotExporter.NukeShotExporter._beforeNukeScriptWrite(self, script)
@@ -264,27 +264,30 @@ class ShotgunNukeShotExporter(ShotgunHieroObjectBase, FnNukeShotExporter.NukeSho
         # now extract the last node's layout and keep hold of it so we can add it back on.
         oldLayoutEnd = currentLayoutContext.getNodes().pop()
 
-        for toolkit_specifier in self._preset.properties()["toolkitWriteNodes"]:
-            # break down a string like 'Toolkit Node: Mono Dpx ("editorial")' into name and output
-            match = re.match("^Toolkit Node: (?P<name>.+) \(\"(?P<output>.+)\"\)",
-                toolkit_specifier)
+        try:
+            for toolkit_specifier in self._preset.properties()["toolkitWriteNodes"]:
+                # break down a string like 'Toolkit Node: Mono Dpx ("editorial")' into name and output
+                match = re.match("^Toolkit Node: (?P<name>.+) \(\"(?P<output>.+)\"\)",
+                    toolkit_specifier)
 
-            metadata = match.groupdict()
-            node = nuke.MetadataNode(metadatavalues=metadata.items())
-            node.setName('ShotgunWriteNodePlaceholder')
+                metadata = match.groupdict()
+                node = nuke.MetadataNode(metadatavalues=metadata.items())
+                node.setName('ShotgunWriteNodePlaceholder')
 
-            self.app.log_debug("Created ShotgunWriteNodePlaceholder Node: %s" % node._knobValues)
-            # rather than using the script.addNode, we append our node directly to the nodeList
-            nodeList.append(node)
+                self.app.log_debug("Created ShotgunWriteNodePlaceholder Node: %s" % node._knobValues)
+                # rather than using the script.addNode, we append our node directly to the nodeList
+                nodeList.append(node)
 
-            # now add our new node to the layout
-            currentLayoutContext.getNodes().append(node)
-
-        # now put back the viewer nodes layout
-        currentLayoutContext.getNodes().append(oldLayoutEnd)
-
-        # put the old end Node back
-        nodeList.append(oldScriptEnd)
+                # now add our new node to the layout
+                currentLayoutContext.getNodes().append(node)
+        except Exception:
+            self.app.logger.exception("Failed to add SG writenodes")
+        finally:
+            # now put back the viewer nodes layout
+            currentLayoutContext.getNodes().append(oldLayoutEnd)
+    
+            # put the old end Node back
+            nodeList.append(oldScriptEnd)
 
 
 class ShotgunNukeShotPreset(ShotgunHieroObjectBase, FnNukeShotExporter.NukeShotPreset, CollatedShotPreset):

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -246,7 +246,7 @@ class ShotgunNukeShotExporter(ShotgunHieroObjectBase, FnNukeShotExporter.NukeSho
 
     def _beforeNukeScriptWrite(self, script):
         """
-        AddShotgunWriteNodePlaceholder Metadata nodes for tk-nuke-writenode to
+        Add ShotgunWriteNodePlaceholder Metadata nodes for tk-nuke-writenode to
         create full Tk WriteNodes in the Nuke environment
         """
         FnNukeShotExporter.NukeShotExporter._beforeNukeScriptWrite(self, script)


### PR DESCRIPTION
This pull request fixes an issue with our export process where our SG writenodes didn't get attached to the rest of the script tree on the exported script:
<img width="192" alt="script tree" src="https://user-images.githubusercontent.com/3777228/56244175-28f3bf80-6094-11e9-9a1d-cce96ae8bf3d.png">
After the fix its now like this:
<img width="128" alt="Untitled__modified__-_Nuke" src="https://user-images.githubusercontent.com/3777228/56244205-3f9a1680-6094-11e9-9fe9-56e657f7f9cf.png">

The way the fix works is by manually modifying the script object and temporarily removing the viewer node (the last node in the script) then adding the SG writenodes and then readding the viewer node back.
