### PR TITLE
SG 22774 write audio to file passed wrong number of args

### DIFF
--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -26,7 +26,7 @@ from hiero import core
 from hiero.core import *
 
 from . import HieroGetShot
-
+import nuke
 
 class ShotgunAudioExporterUI(ShotgunHieroObjectBase, FnAudioExportUI.AudioExportUI):
     """
@@ -77,10 +77,8 @@ class ShotgunAudioExporter(
         self._resolved_export_path = None
         self._sequence_name = None
         self._thumbnail = None
+        self._initDict = initDict
 
-        # Retrieving the bithDepth and bitRate values
-        self._bitDepth = initDict["preset"]._properties["bitDepth"]
-        self._bitRate = initDict["preset"]._properties["bitRate"]
 
         # Only publish combined audio. This is done by only publishing video track output
         self._do_publish = self._item.mediaType() is core.TrackItem.MediaType.kVideo
@@ -191,8 +189,6 @@ class ShotgunAudioExporter(
                     # Versions of Nuke >= 13  require the additional parameters 3 and 2 to be passed to
                     # the writeAudioToFile method.
                     # Check Nuke´s version
-                    import nuke
-
                     nuke_version = (
                         nuke.NUKE_VERSION_MAJOR,
                         nuke.NUKE_VERSION_MINOR,
@@ -200,15 +196,17 @@ class ShotgunAudioExporter(
                     )
 
                     if nuke_version[0] >= 13:
-                        bitDepth_data = self._bitDepth
-                        bitRate_data = self._bitRate
+                        # Retrieving the bithDepth and bitRate values for nuke version >= 13
+                        bitDepth_data = self._initDict["preset"]._properties["bitDepth"]
+                        bitRate_data = self._initDict["preset"]._properties["bitRate"]
+
                         bitDepth = [
                             int(s) for s in bitDepth_data.split() if s.isdigit()
                         ][0]
                         bitRate = [int(s) for s in bitRate_data.split() if s.isdigit()][
                             0
                         ]
-                        # Let´s pass the bitDepth and bitRate parameters
+                        # Let´s pass the bitDepth and bitRate parameters to writeAudioToFile method
                         self._sequence.writeAudioToFile(
                             self._audioFile, start, end, bitDepth, bitRate
                         )

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -79,8 +79,8 @@ class ShotgunAudioExporter(
         self._thumbnail = None
 
         # Retrieving the bithDepth and bitRate values
-        self._bitDepth = initDict['preset']._properties['bitDepth']
-        self._bitRate = initDict['preset']._properties['bitRate']
+        self._bitDepth = initDict["preset"]._properties["bitDepth"]
+        self._bitRate = initDict["preset"]._properties["bitRate"]
 
         # Only publish combined audio. This is done by only publishing video track output
         self._do_publish = self._item.mediaType() is core.TrackItem.MediaType.kVideo
@@ -192,6 +192,7 @@ class ShotgunAudioExporter(
                     # the writeAudioToFile method.
                     # Check Nuke´s version
                     import nuke
+
                     nuke_version = (
                         nuke.NUKE_VERSION_MAJOR,
                         nuke.NUKE_VERSION_MINOR,
@@ -201,14 +202,19 @@ class ShotgunAudioExporter(
                     if nuke_version[0] >= 13:
                         bitDepth_data = self._bitDepth
                         bitRate_data = self._bitRate
-                        bitDepth = [int(s) for s in bitDepth_data.split() if s.isdigit()][0]
-                        bitRate = [int(s) for s in bitRate_data.split() if s.isdigit()][0]
+                        bitDepth = [
+                            int(s) for s in bitDepth_data.split() if s.isdigit()
+                        ][0]
+                        bitRate = [int(s) for s in bitRate_data.split() if s.isdigit()][
+                            0
+                        ]
                         # Let´s pass the bitDepth and bitRate parameters
-                        self._sequence.writeAudioToFile(self._audioFile, start, end, bitDepth, bitRate)
+                        self._sequence.writeAudioToFile(
+                            self._audioFile, start, end, bitDepth, bitRate
+                        )
 
                     elif nuke_version[0] < 13:
                         self._sequence.writeAudioToFile(self._audioFile, start, end)
-
 
         elif isinstance(item, Clip):
             # If item is clip, we're writing out the clip audio not the whole sequence

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -202,12 +202,18 @@ class ShotgunAudioExporter(
                         bitDepth = [
                             int(s) for s in bitDepth_str.split() if s.isdigit()
                         ][0]
-                        bitRate = [
-                            int(s) for s in bitRate_str.split() if s.isdigit()
+                        bitRate = [int(s) for s in bitRate_str.split() if s.isdigit()][
+                            0
+                        ]
+                        numChannels_str = self._initDict["preset"]._properties[
+                            "numChannels"
+                        ]
+                        sampleRate_str = self._initDict["preset"]._properties[
+                            "sampleRate"
+                        ]
+                        sampleRate = [
+                            int(s) for s in sampleRate_str.split() if s.isdigit()
                         ][0]
-                        numChannels_str = self._initDict["preset"]._properties["numChannels"]
-                        sampleRate_str = self._initDict["preset"]._properties["sampleRate"]
-                        sampleRate = [int(s) for s in sampleRate_str.split() if s.isdigit()][0]
 
                         # numChannels parameter must be passed as an integer
                         if numChannels_str == "mono":
@@ -221,7 +227,13 @@ class ShotgunAudioExporter(
 
                         # If trackitem write out just the audio within the cut
                         self._sequence.writeAudioToFile(
-                            self._audioFile, start, end, numChannels, sampleRate, bitDepth, bitRate
+                            self._audioFile,
+                            start,
+                            end,
+                            numChannels,
+                            sampleRate,
+                            bitDepth,
+                            bitRate,
                         )
 
                     else:

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -28,6 +28,7 @@ from hiero.core import *
 from . import HieroGetShot
 import nuke
 
+
 class ShotgunAudioExporterUI(ShotgunHieroObjectBase, FnAudioExportUI.AudioExportUI):
     """
     Custom Preferences UI for the shotgun audio exporter
@@ -78,7 +79,6 @@ class ShotgunAudioExporter(
         self._sequence_name = None
         self._thumbnail = None
         self._initDict = initDict
-
 
         # Only publish combined audio. This is done by only publishing video track output
         self._do_publish = self._item.mediaType() is core.TrackItem.MediaType.kVideo

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -193,7 +193,9 @@ class ShotgunAudioExporter(
                         nuke.NUKE_VERSION_RELEASE,
                     )
 
-                    if nuke_version[0] > 12 or (nuke_version[0] == 12 and nuke_version[1] > 0):
+                    if nuke_version[0] > 12 or (
+                        nuke_version[0] == 12 and nuke_version[1] > 0
+                    ):
                         # The following values need to be passed as additional arguments to the writeAudioToFile method
                         # in nuke versions >= 12.1:
                         # numChannels[number(int)], sampleRate[Hz], bitDepth[bits], bitRate[kbp/s]

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -193,7 +193,7 @@ class ShotgunAudioExporter(
                         nuke.NUKE_VERSION_RELEASE,
                     )
 
-                    if nuke_version[0] >= 12 and nuke_version[1] > 0:
+                    if nuke_version[0] > 12 or (nuke_version[0] == 12 and nuke_version[1] > 0):
                         # The following values need to be passed as additional arguments to the writeAudioToFile method
                         # in nuke versions >= 12.1:
                         # numChannels[number(int)], sampleRate[Hz], bitDepth[bits], bitRate[kbp/s]


### PR DESCRIPTION
This PR fixes the error "TypeError: writeAudioToFile expected at least 5 arguments, got 3" when exporting audio from Nuke studio >= 12.1. The following changes were made:
- Check the version of Nuke, to determine if it is prior to version 12.1.
- Passing the following additional arguments to the writeAudioToFile() method for Nuke versions >= 12.1.
      numChannels
      sampleRate
      bitDepth
      bitRate
- Converting the numChannels property to an integer.