### PR TITLE
SG-20925 Formalize the deprecation of python 2.6 support in toolkit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python 2.6 2.7 3.7](https://img.shields.io/badge/python-2.6%20%7C%202.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Apps/tk-hiero-export?repoName=shotgunsoftware%2Ftk-hiero-export&branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=95&repoName=shotgunsoftware%2Ftk-hiero-export&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/hooks/hiero_post_version_creation.py
+++ b/hooks/hiero_post_version_creation.py
@@ -15,34 +15,34 @@ HookBaseClass = sgtk.get_hook_baseclass()
 
 class HieroPostVersionCreation(HookBaseClass):
     """
-	This class implements a hook that can be used to add custom logic to
-	be run after a Version entity is created in Shotgun as part of the
-	export process.
-	"""
+    This class implements a hook that can be used to add custom logic to
+    be run after a Version entity is created in Shotgun as part of the
+    export process.
+    """
 
     def execute(self, version_data, **kwargs):
         """
-		Runs following the creation of the Version entity in Shotgun. The
-		provided version data is the data structure containing information
-		about the Version entity, including its ID in Shotgun.
+        Runs following the creation of the Version entity in Shotgun. The
+        provided version data is the data structure containing information
+        about the Version entity, including its ID in Shotgun.
 
-		Example version_data:
+        Example version_data:
 
-		.. code-block:: python
+        .. code-block:: python
 
-			{'code': 'Scene_v031_abc',
-			 'created_by': {'id': 39, 'name': 'Jeff Beeland', 'type': 'HumanUser'},
-			 'entity': {'id': 1166, 'name': 'ABC', 'type': 'Shot'},
-			 'id': 6039,
-			 'project': {'id': 74, 'name': 'DevWindows', 'type': 'Project'},
-			 'published_files': [{'id': 108,
-			                      'name': 'scene_v031_ABC.mov',
-			                      'type': 'PublishedFile'}],
-			 'sg_path_to_movie': '/shotgun/projects/devwindows/sequences/123/ABC/editorial/2015_11_24/plates/scene_v031_ABC.mov',
-			 'sg_task': {'id': 2113, 'name': 'Comp', 'type': 'Task'},
-			 'type': 'Version',
-			 'user': {'id': 39, 'name': 'Jeff Beeland', 'type': 'HumanUser'}}
+                {'code': 'Scene_v031_abc',
+                 'created_by': {'id': 39, 'name': 'Jeff Beeland', 'type': 'HumanUser'},
+                 'entity': {'id': 1166, 'name': 'ABC', 'type': 'Shot'},
+                 'id': 6039,
+                 'project': {'id': 74, 'name': 'DevWindows', 'type': 'Project'},
+                 'published_files': [{'id': 108,
+                                      'name': 'scene_v031_ABC.mov',
+                                      'type': 'PublishedFile'}],
+                 'sg_path_to_movie': '/shotgun/projects/devwindows/sequences/123/ABC/editorial/2015_11_24/plates/scene_v031_ABC.mov',
+                 'sg_task': {'id': 2113, 'name': 'Comp', 'type': 'Task'},
+                 'type': 'Version',
+                 'user': {'id': 39, 'name': 'Jeff Beeland', 'type': 'HumanUser'}}
 
-		:param dict version_data: The Version entity that was created in Shotgun.
-		"""
+        :param dict version_data: The Version entity that was created in Shotgun.
+        """
         pass

--- a/python/base_hooks/hiero_post_version_creation.py
+++ b/python/base_hooks/hiero_post_version_creation.py
@@ -15,34 +15,34 @@ HookBaseClass = sgtk.get_hook_baseclass()
 
 class HieroPostVersionCreation(HookBaseClass):
     """
-	This class implements a hook that can be used to add custom logic to
-	be run after a Version entity is created in Shotgun as part of the
-	export process.
-	"""
+    This class implements a hook that can be used to add custom logic to
+    be run after a Version entity is created in Shotgun as part of the
+    export process.
+    """
 
     def execute(self, version_data, **kwargs):
         """
-		Runs following the creation of the Version entity in Shotgun. The
-		provided version data is the data structure containing information
-		about the Version entity, including its ID in Shotgun.
+        Runs following the creation of the Version entity in Shotgun. The
+        provided version data is the data structure containing information
+        about the Version entity, including its ID in Shotgun.
 
-		Example version_data:
+        Example version_data:
 
-		.. code-block:: python
+        .. code-block:: python
 
-			{'code': 'Scene_v031_abc',
-			 'created_by': {'id': 39, 'name': 'Jeff Beeland', 'type': 'HumanUser'},
-			 'entity': {'id': 1166, 'name': 'ABC', 'type': 'Shot'},
-			 'id': 6039,
-			 'project': {'id': 74, 'name': 'DevWindows', 'type': 'Project'},
-			 'published_files': [{'id': 108,
-			                      'name': 'scene_v031_ABC.mov',
-			                      'type': 'PublishedFile'}],
-			 'sg_path_to_movie': '/shotgun/projects/devwindows/sequences/123/ABC/editorial/2015_11_24/plates/scene_v031_ABC.mov',
-			 'sg_task': {'id': 2113, 'name': 'Comp', 'type': 'Task'},
-			 'type': 'Version',
-			 'user': {'id': 39, 'name': 'Jeff Beeland', 'type': 'HumanUser'}}
+                {'code': 'Scene_v031_abc',
+                 'created_by': {'id': 39, 'name': 'Jeff Beeland', 'type': 'HumanUser'},
+                 'entity': {'id': 1166, 'name': 'ABC', 'type': 'Shot'},
+                 'id': 6039,
+                 'project': {'id': 74, 'name': 'DevWindows', 'type': 'Project'},
+                 'published_files': [{'id': 108,
+                                      'name': 'scene_v031_ABC.mov',
+                                      'type': 'PublishedFile'}],
+                 'sg_path_to_movie': '/shotgun/projects/devwindows/sequences/123/ABC/editorial/2015_11_24/plates/scene_v031_ABC.mov',
+                 'sg_task': {'id': 2113, 'name': 'Comp', 'type': 'Task'},
+                 'type': 'Version',
+                 'user': {'id': 39, 'name': 'Jeff Beeland', 'type': 'HumanUser'}}
 
-		:param dict version_data: The Version entity that was created in Shotgun.
-		"""
+        :param dict version_data: The Version entity that was created in Shotgun.
+        """
         pass

--- a/python/tk_hiero_export/base.py
+++ b/python/tk_hiero_export/base.py
@@ -124,7 +124,8 @@ class ShotgunHieroObjectBase(object):
             # but that's safe here because we only support Hiero/NS versions that
             # come bundled with 2.7.
             cache = self._custom_properties.setdefault(
-                get_method, collections.OrderedDict(),
+                get_method,
+                collections.OrderedDict(),
             )
 
             for prop_data in hook_ui_properties:
@@ -147,8 +148,7 @@ class ShotgunHieroObjectBase(object):
         return hook_widget
 
     def _formatTkVersionString(self, hiero_version_str):
-        """Reformat the Hiero version string to the tk format.
-        """
+        """Reformat the Hiero version string to the tk format."""
         try:
             version_number = int(hiero_version_str[1:])
         except ValueError:

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -94,7 +94,7 @@ class ShotgunAudioExporter(
             return FnAudioExportTask.AudioExportTask.sequenceName(self)
 
     def startTask(self):
-        """ Run Task """
+        """Run Task"""
         if self._resolved_export_path is None:
             self._resolved_export_path = self.resolvedExportPath()
             self._tk_version = self._formatTkVersionString(self.versionString())
@@ -258,7 +258,7 @@ class ShotgunAudioExporter(
         return False
 
     def finishTask(self):
-        """ Finish Task """
+        """Finish Task"""
         # run base class implementation
         FnAudioExportTask.AudioExportTask.finishTask(self)
 

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -163,7 +163,7 @@ class ShotgunNukeShotExporter(
         return FnNukeShotExporter.NukeShotExporter.taskStep(self)
 
     def startTask(self):
-        """ Run Task """
+        """Run Task"""
         # call the publish data hook to allow for publish customization while _item is valid (unlike finishTask)
         self._extra_publish_data = self.app.execute_hook(
             "hook_get_extra_publish_data",

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -343,7 +343,9 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         # Call pre processor hook here to make sure it happens pior to any 'hook_resolve_custom_strings'.
         # The order if execution is basically [init processor, resolve user entries, startProcessing].
         self.app.execute_hook(
-            "hook_pre_export", processor=self, base_class=HieroPreExport,
+            "hook_pre_export",
+            processor=self,
+            base_class=HieroPreExport,
         )
 
     def startProcessing(self, exportItems, preview=False):
@@ -378,7 +380,8 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
                 get_method="get_shot_processor_ui_properties",
             )
             sg_shot_properties = self._preset.properties().get(
-                "shotgunShotCreateProperties", dict(),
+                "shotgunShotCreateProperties",
+                dict(),
             )
 
             for property_data in custom_properties:
@@ -507,7 +510,8 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
             "hook_update_cuts",
             "allow_cut_updates",
             preset_properties=self._preset.properties().get(
-                "shotgunShotCreateProperties", dict(),
+                "shotgunShotCreateProperties",
+                dict(),
             ),
             base_class=HieroUpdateCuts,
         )

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -130,7 +130,7 @@ class ShotgunTranscodeExporter(
     _write_set_node_label = "SG_Write_Attachment"
 
     def __init__(self, initDict):
-        """ Constructor """
+        """Constructor"""
         FnTranscodeExporter.TranscodeExporter.__init__(self, initDict)
         CollatingExporter.__init__(self)
         self._resolved_export_path = None
@@ -209,7 +209,10 @@ class ShotgunTranscodeExporter(
         )
         self.app.log_info("Transcode quicktime settings: %s" % (properties,))
         preset.properties().update(
-            {"file_type": file_type, file_type: properties,}
+            {
+                "file_type": file_type,
+                file_type: properties,
+            }
         )
 
         # Sadly Foundry has a habit of changing the interfaces of
@@ -280,7 +283,7 @@ class ShotgunTranscodeExporter(
         return result
 
     def startTask(self):
-        """ Run Task """
+        """Run Task"""
         if self._resolved_export_path is None:
             self._resolved_export_path = self.resolvedExportPath()
             self._tk_version = self._formatTkVersionString(self.versionString())
@@ -390,7 +393,7 @@ class ShotgunTranscodeExporter(
         return FnTranscodeExporter.TranscodeExporter.startTask(self)
 
     def finishTask(self):
-        """ Finish Task """
+        """Finish Task"""
         # run base class implementation
         FnTranscodeExporter.TranscodeExporter.finishTask(self)
 
@@ -501,7 +504,7 @@ class ShotgunTranscodeExporter(
 class ShotgunTranscodePreset(
     ShotgunHieroObjectBase, FnTranscodeExporter.TranscodePreset, CollatedShotPreset
 ):
-    """ Settings for the SG transcode step """
+    """Settings for the SG transcode step"""
 
     def __init__(self, name, properties):
         FnTranscodeExporter.TranscodePreset.__init__(self, name, properties)


### PR DESCRIPTION
This PR includes the actions to remove Python 2.6 support in toolkit:
        - Remove python 2.6 badges
        - Update setup.py to drop support for 2.6
        - Update the documentation and the developer.shotgunsoftware.com doc site