### PR TITLE
SG-38666 Fix the MRO issue by switching the parameter to optional

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,12 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+default_language_version:
+    python: python3
+
 # Exclude the UI files, as they are auto-generated.
 exclude: "ui\/.*py$"
+
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -17,7 +21,6 @@ repos:
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
-      language_version: python3
     # Ensures a file name will resolve on all platform
     - id: check-case-conflict
     # Checks files with the execute bit set have shebangs
@@ -35,4 +38,3 @@ repos:
     rev: 25.1.0
     hooks:
     - id: black
-      language_version: python3

--- a/python/tk_hiero_export/collating_exporter.py
+++ b/python/tk_hiero_export/collating_exporter.py
@@ -796,14 +796,19 @@ class CollatedShotPreset(object):
     def __init__(self, properties=None):
         """
         properties is an optional parameter because of the cooperative
-        multiple-inheritance paradigm in python
+        multiple-inheritance paradigm in python.
 
         Child classes are using multiple inheritance with classes coming from
         The Foundry. Some of those classes call `super` in the contrusctor
-        instead of their direct parent but `__init__` methods have different
-        signatures.
+        instead of their direct parent but `__init__` methods in the MRO have
+        different signatures causing this method to be called with no
+        parameters.
 
         For more information: https://medium.com/swlh/cooperative-multiple-inheritance-paradigm-in-python-f048b7ecdb29
+
+        The method is manually called a second time with the properties
+        parameters by the child class calling their direct parent (instead of
+        `super`).
         """
 
         if properties:

--- a/python/tk_hiero_export/collating_exporter.py
+++ b/python/tk_hiero_export/collating_exporter.py
@@ -793,10 +793,17 @@ def _subTrackIndex(subTrackItem):
 
 
 class CollatedShotPreset(object):
-    def __init__(self, properties):
-        properties["collateTracks"] = False
-        properties["collateShotNames"] = False
+    def __init__(self, properties=None):
+        """
+        properties is an optional parameter because of a MRO issue with Python
+        3.11.
+        TODO more digging
+        """
 
-        # Not exposed in UI
-        properties["collateSequence"] = False  # Collate all trackitems within sequence
-        properties["collateCustomStart"] = True  # Start frame is inclusive of handles
+        if properties:
+            properties["collateTracks"] = False
+            properties["collateShotNames"] = False
+
+            # Not exposed in UI
+            properties["collateSequence"] = False  # Collate all trackitems within sequence
+            properties["collateCustomStart"] = True  # Start frame is inclusive of handles

--- a/python/tk_hiero_export/collating_exporter.py
+++ b/python/tk_hiero_export/collating_exporter.py
@@ -813,6 +813,9 @@ class CollatedShotPreset(object):
             properties["collateTracks"] = False
             properties["collateShotNames"] = False
 
-            # Not exposed in UI
-            properties["collateSequence"] = False  # Collate all trackitems within sequence
-            properties["collateCustomStart"] = True  # Start frame is inclusive of handles
+            # Following ones are not exposed in UI
+
+            # Collate all trackitems within sequence
+            properties["collateSequence"] = False
+            # Start frame is inclusive of handles
+            properties["collateCustomStart"] = True

--- a/python/tk_hiero_export/collating_exporter.py
+++ b/python/tk_hiero_export/collating_exporter.py
@@ -797,18 +797,16 @@ class CollatedShotPreset(object):
         """
         properties is an optional parameter because of the cooperative
         multiple-inheritance paradigm in python.
-
-        Child classes are using multiple inheritance with classes coming from
-        The Foundry. Some of those classes call `super` in the contrusctor
-        instead of their direct parent but `__init__` methods in the MRO have
-        different signatures causing this method to be called with no
-        parameters.
-
         For more information: https://medium.com/swlh/cooperative-multiple-inheritance-paradigm-in-python-f048b7ecdb29
 
-        The method is manually called a second time with the properties
-        parameters by the child class calling their direct parent (instead of
-        `super`).
+        Child classes are using multiple inheritance with sibling classes callin
+        `super` instead of their direct. However, `__init__` methods in the MRO
+        do not all have the same signature, causing this method to be called
+        with no parameters.
+
+        The method is manually called a second time by the child class,
+        providing the `properties` parameters (by addressing their direct parent
+        instead of using `super`).
         """
 
         if properties:

--- a/python/tk_hiero_export/collating_exporter.py
+++ b/python/tk_hiero_export/collating_exporter.py
@@ -795,9 +795,15 @@ def _subTrackIndex(subTrackItem):
 class CollatedShotPreset(object):
     def __init__(self, properties=None):
         """
-        properties is an optional parameter because of a MRO issue with Python
-        3.11.
-        TODO more digging
+        properties is an optional parameter because of the cooperative
+        multiple-inheritance paradigm in python
+
+        Child classes are using multiple inheritance with classes coming from
+        The Foundry. Some of those classes call `super` in the contrusctor
+        instead of their direct parent but `__init__` methods have different
+        signatures.
+
+        For more information: https://medium.com/swlh/cooperative-multiple-inheritance-paradigm-in-python-f048b7ecdb29
         """
 
         if properties:

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -198,7 +198,7 @@ class ShotgunShotProcessorUI(
             properties["sg_cut_type"] = new_value
 
         # connect the widget index changed to the callback
-        cut_type_widget.currentIndexChanged[str].connect(value_changed)
+        cut_type_widget.currentTextChanged.connect(value_changed)
 
         # ---- construct the layout with a label
 
@@ -250,7 +250,7 @@ class ShotgunShotProcessorUI(
         tagTable.setMinimumHeight(150)
         tagTable.setHorizontalHeaderLabels(["Hiero Tags"] + labels)
         tagTable.setAlternatingRowColors(True)
-        tagTable.setSelectionMode(tagTable.NoSelection)
+        tagTable.setSelectionMode(QtGui.QAbstractItemView.SelectionMode.NoSelection)
         tagTable.setShowGrid(False)
         tagTable.verticalHeader().hide()
         tagTable.horizontalHeader().setStretchLastSection(True)
@@ -298,7 +298,7 @@ class ShotgunShotProcessorUI(
                 # adjust sizes to avoid clipping or scrolling
                 width = combo.minimumSizeHint().width()
                 combo.setMinimumWidth(width)
-                combo.setSizeAdjustPolicy(combo.AdjustToContents)
+                combo.setSizeAdjustPolicy(QtGui.QComboBox.SizeAdjustPolicy.AdjustToContents)
                 tagTable.setCellWidget(row, col + 1, combo)
 
         tagTable.resizeRowsToContents()


### PR DESCRIPTION
Integration does not load on Nuke/Hiero version 16.0v1 and raises the following traceback:
```python
Traceback (most recent call last):
  File "configs\demo_animation\install\core\python\tank\platform\engine.py", line 2723, in __load_apps
    app.init_app()
  File "tk-hiero-export\app.py", line 91, in init_app
    self._register_exporter()
  File "tk-hiero-export\app.py", line 172, in _register_exporter
    hiero.ui.taskUIRegistry.registerTaskUI(
  File "C:\Program Files\Nuke16.0v1\pythonextensions\site-packages\hiero\ui\FnExportUIRegistry.py", line 20, in registerTaskUI
    presetInstance = taskPreset("dummypreset", dict())
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "tk-hiero-export\python\tk_hiero_export\version_creator.py", line 511, in __init__
    FnTranscodeExporter.TranscodePreset.__init__(self, name, properties)
  File "C:\Program Files\Nuke16.0v1\pythonextensions\site-packages\hiero\exporters\FnTranscodeExporter.py", line 710, in __init__
    hiero.core.RenderTaskPreset.__init__(self, TranscodeExporter, name, properties)
  File "C:\Program Files\Nuke16.0v1\pythonextensions\site-packages\hiero\core\FnExporterBase.py", line 1233, in __init__
    TaskPresetBase.__init__(self, taskType, name)
  File "C:\Program Files\Nuke16.0v1\pythonextensions\site-packages\hiero\core\FnExporterBase.py", line 849, in __init__
    ITaskPreset.__init__(self)
TypeError: CollatedShotPreset.__init__() missing 1 required positional argument: 'properties'
```

This is related to [the cooperative multiple-inheritance paradigm in Python](https://medium.com/swlh/cooperative-multiple-inheritance-paradigm-in-python-f048b7ecdb29).

Child classes of `CollatedShotPreset` use multiple inheritance, with sibling classes calling `super` instead of their direct parent. However, `__init__` methods in the MRO do not all have the same signature, causing this method to be called with no parameters.

The method is manually called a second time by the child class, providing the `properties` parameters (by addressing their direct parent instead of using `super`).