### PR TITLE
SG-38666 Add compatibility with Nuke 16

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,12 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+default_language_version:
+    python: python3
+
 # Exclude the UI files, as they are auto-generated.
 exclude: "ui\/.*py$"
+
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -17,7 +21,6 @@ repos:
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
-      language_version: python3
     # Ensures a file name will resolve on all platform
     - id: check-case-conflict
     # Checks files with the execute bit set have shebangs
@@ -35,4 +38,3 @@ repos:
     rev: 25.1.0
     hooks:
     - id: black
-      language_version: python3

--- a/python/tk_hiero_export/collating_exporter.py
+++ b/python/tk_hiero_export/collating_exporter.py
@@ -16,8 +16,6 @@ import hiero
 
 class CollatingExporter(object):
     def __init__(self, properties=None):
-        super(CollatingExporter, self).__init__()
-
         # When building a collated sequence, everything is offset by 1000
         # This gives head room for shots which may go negative when transposed to a
         # custom start frame. This offset should be negated during script generation.

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -144,7 +144,12 @@ class ShotgunAudioExporter(
         # figure out the thumbnail frame
         ##########################
         source = self._item.source()
-        self._thumbnail = source.thumbnail(source.posterFrame())
+        try:
+            self._thumbnail = source.thumbnail(source.posterFrame())
+        except RuntimeError:
+            # Nuke 16.0 issues a RuntimeError when trying to get the thumbnail
+            # RuntimeError: Layer does not exist
+            self.app.logger.error("Unable to extract thumbnail", exc_info=True)
 
         return FnAudioExportTask.AudioExportTask.startTask(self)
 

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -304,7 +304,7 @@ class ShotgunAudioExporter(
 
 
 class ShotgunAudioPreset(
-    CollatedShotPreset, ShotgunHieroObjectBase, FnAudioExportTask.AudioExportPreset
+    ShotgunHieroObjectBase, CollatedShotPreset, FnAudioExportTask.AudioExportPreset
 ):
     """
     Settings for the shotgun audio export step

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -62,7 +62,7 @@ class ShotgunAudioExporterUI(ShotgunHieroObjectBase, FnAudioExportUI.AudioExport
 
 
 class ShotgunAudioExporter(
-    ShotgunHieroObjectBase, FnAudioExportTask.AudioExportTask, CollatingExporter
+    CollatingExporter, ShotgunHieroObjectBase, FnAudioExportTask.AudioExportTask
 ):
     """
     Create Audio object and send to Shotgun
@@ -304,7 +304,7 @@ class ShotgunAudioExporter(
 
 
 class ShotgunAudioPreset(
-    ShotgunHieroObjectBase, FnAudioExportTask.AudioExportPreset, CollatedShotPreset
+    CollatedShotPreset, ShotgunHieroObjectBase, FnAudioExportTask.AudioExportPreset
 ):
     """
     Settings for the shotgun audio export step

--- a/python/tk_hiero_export/sg_audio_export.py
+++ b/python/tk_hiero_export/sg_audio_export.py
@@ -62,7 +62,7 @@ class ShotgunAudioExporterUI(ShotgunHieroObjectBase, FnAudioExportUI.AudioExport
 
 
 class ShotgunAudioExporter(
-    CollatingExporter, ShotgunHieroObjectBase, FnAudioExportTask.AudioExportTask
+    ShotgunHieroObjectBase, CollatingExporter, FnAudioExportTask.AudioExportTask
 ):
     """
     Create Audio object and send to Shotgun

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -318,7 +318,7 @@ class ShotgunNukeShotExporter(
 
 
 class ShotgunNukeShotPreset(
-    CollatedShotPreset, ShotgunHieroObjectBase, FnNukeShotExporter.NukeShotPreset
+    ShotgunHieroObjectBase, CollatedShotPreset, FnNukeShotExporter.NukeShotPreset
 ):
     """
     Settings for the shotgun transcode step

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -158,7 +158,12 @@ class ShotgunNukeShotExporter(
             )
 
         source = self._item.source()
-        self._thumbnail = source.thumbnail(source.posterFrame())
+        try:
+            self._thumbnail = source.thumbnail(source.posterFrame())
+        except RuntimeError:
+            # Nuke 16.0 issues a RuntimeError when trying to get the thumbnail
+            # RuntimeError: Layer does not exist
+            self.app.logger.error("Unable to extract thumbnail", exc_info=True)
 
         return FnNukeShotExporter.NukeShotExporter.taskStep(self)
 

--- a/python/tk_hiero_export/sg_nuke_shot_export.py
+++ b/python/tk_hiero_export/sg_nuke_shot_export.py
@@ -318,7 +318,7 @@ class ShotgunNukeShotExporter(
 
 
 class ShotgunNukeShotPreset(
-    ShotgunHieroObjectBase, FnNukeShotExporter.NukeShotPreset, CollatedShotPreset
+    CollatedShotPreset, ShotgunHieroObjectBase, FnNukeShotExporter.NukeShotPreset
 ):
     """
     Settings for the shotgun transcode step

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -834,7 +834,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
 
 
 class ShotgunShotProcessorPreset(
-    ShotgunHieroObjectBase, FnShotProcessor.ShotProcessorPreset, CollatedShotPreset
+    CollatedShotPreset, ShotgunHieroObjectBase, FnShotProcessor.ShotProcessorPreset
 ):
     """
     Handles presets for the shot processor.

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -836,7 +836,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
 
 
 class ShotgunShotProcessorPreset(
-    CollatedShotPreset, ShotgunHieroObjectBase, FnShotProcessor.ShotProcessorPreset
+    ShotgunHieroObjectBase, CollatedShotPreset, FnShotProcessor.ShotProcessorPreset
 ):
     """
     Handles presets for the shot processor.

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -198,7 +198,7 @@ class ShotgunShotProcessorUI(
             properties["sg_cut_type"] = new_value
 
         # connect the widget index changed to the callback
-        cut_type_widget.currentIndexChanged[str].connect(value_changed)
+        cut_type_widget.currentTextChanged.connect(value_changed)
 
         # ---- construct the layout with a label
 
@@ -250,7 +250,7 @@ class ShotgunShotProcessorUI(
         tagTable.setMinimumHeight(150)
         tagTable.setHorizontalHeaderLabels(["Hiero Tags"] + labels)
         tagTable.setAlternatingRowColors(True)
-        tagTable.setSelectionMode(tagTable.NoSelection)
+        tagTable.setSelectionMode(QtGui.QAbstractItemView.SelectionMode.NoSelection)
         tagTable.setShowGrid(False)
         tagTable.verticalHeader().hide()
         tagTable.horizontalHeader().setStretchLastSection(True)
@@ -298,7 +298,7 @@ class ShotgunShotProcessorUI(
                 # adjust sizes to avoid clipping or scrolling
                 width = combo.minimumSizeHint().width()
                 combo.setMinimumWidth(width)
-                combo.setSizeAdjustPolicy(combo.AdjustToContents)
+                combo.setSizeAdjustPolicy(QtGui.QComboBox.SizeAdjustPolicy.AdjustToContents)
                 tagTable.setCellWidget(row, col + 1, combo)
 
         tagTable.resizeRowsToContents()

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -298,7 +298,9 @@ class ShotgunShotProcessorUI(
                 # adjust sizes to avoid clipping or scrolling
                 width = combo.minimumSizeHint().width()
                 combo.setMinimumWidth(width)
-                combo.setSizeAdjustPolicy(QtGui.QComboBox.SizeAdjustPolicy.AdjustToContents)
+                combo.setSizeAdjustPolicy(
+                    QtGui.QComboBox.SizeAdjustPolicy.AdjustToContents
+                )
                 tagTable.setCellWidget(row, col + 1, combo)
 
         tagTable.resizeRowsToContents()

--- a/python/tk_hiero_export/shot_updater.py
+++ b/python/tk_hiero_export/shot_updater.py
@@ -22,7 +22,7 @@ from . import (
 
 
 class ShotgunShotUpdater(
-    ShotgunHieroObjectBase, FnShotExporter.ShotTask, CollatingExporter
+    CollatingExporter, ShotgunHieroObjectBase, FnShotExporter.ShotTask
 ):
     """
     Ensures that Shots and Sequences exist in Shotgun

--- a/python/tk_hiero_export/shot_updater.py
+++ b/python/tk_hiero_export/shot_updater.py
@@ -120,6 +120,10 @@ class ShotgunShotUpdater(
             "working_duration": working_duration,
         }
 
+    def finishTask(self):
+        FnShotExporter.ShotTask.finishTask(self)
+        CollatingExporter.finishTask(self)
+
     def taskStep(self):
         """
         Execution payload.

--- a/python/tk_hiero_export/shot_updater.py
+++ b/python/tk_hiero_export/shot_updater.py
@@ -22,7 +22,7 @@ from . import (
 
 
 class ShotgunShotUpdater(
-    CollatingExporter, ShotgunHieroObjectBase, FnShotExporter.ShotTask
+    ShotgunHieroObjectBase, CollatingExporter, FnShotExporter.ShotTask
 ):
     """
     Ensures that Shots and Sequences exist in Shotgun

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -119,7 +119,7 @@ class ShotgunTranscodeExporterUI(
 
 
 class ShotgunTranscodeExporter(
-    CollatingExporter, ShotgunHieroObjectBase, FnTranscodeExporter.TranscodeExporter
+    ShotgunHieroObjectBase, CollatingExporter, FnTranscodeExporter.TranscodeExporter
 ):
     """
     Create Transcode object and send to Shotgun
@@ -503,7 +503,7 @@ class ShotgunTranscodeExporter(
 
 
 class ShotgunTranscodePreset(
-    CollatedShotPreset, ShotgunHieroObjectBase, FnTranscodeExporter.TranscodePreset
+    ShotgunHieroObjectBase, CollatedShotPreset, FnTranscodeExporter.TranscodePreset
 ):
     """Settings for the PTR transcode step"""
 

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -119,7 +119,7 @@ class ShotgunTranscodeExporterUI(
 
 
 class ShotgunTranscodeExporter(
-    ShotgunHieroObjectBase, FnTranscodeExporter.TranscodeExporter, CollatingExporter
+    CollatingExporter, ShotgunHieroObjectBase, FnTranscodeExporter.TranscodeExporter
 ):
     """
     Create Transcode object and send to Shotgun
@@ -503,7 +503,7 @@ class ShotgunTranscodeExporter(
 
 
 class ShotgunTranscodePreset(
-    ShotgunHieroObjectBase, FnTranscodeExporter.TranscodePreset, CollatedShotPreset
+    CollatedShotPreset, ShotgunHieroObjectBase, FnTranscodeExporter.TranscodePreset
 ):
     """Settings for the PTR transcode step"""
 


### PR DESCRIPTION
Change the order of inheritance for multi-inheritance classes as a workaround for a known issue with PySide6.
Relates to PixarAnimationStudios/OpenUSD#2392

Replace #61


Also fix incompatibilities with PySide6.

# PySide6 multi-inheritance regression

Considering this code:

```python
try:
    from PySide6 import QtCore, QtWidgets
except ImportError:
    from PySide2 import QtCore, QtWidgets

class C1:
    def __init__(self, mandatory_parameter):
        pass

class C2(QtCore.QObject, C1):
    def __init__(self):
        QtCore.QObject.__init__(self)
        C1.__init__(self, True)

if __name__ == "__main__":
    app = QtWidgets.QApplication()
    o1 = C2()
```

Tested with various PySide2-6 versions:

| PySide version  | Result |
|-----------------|--------|
| 5.15.16         | ✅     |
| 6.4.3           | ✅     |
| 6.5.3           | ❌     |
| 6.8.3           | ❌     |


```python
Traceback (most recent call last):
  File "test.py", line 22, in <module>
    o1 = C2()
         ^^^^
  File "test.py", line 16, in __init__
    QtCore.QObject.__init__(self)
TypeError: C1.__init__() missing 1 required positional argument: 'mandatory_parameter'
```

Reported at Qt: https://bugreports.qt.io/browse/PYSIDE-2304. Marked as fixed even if not fixed... :( 


