### PR TITLE
SG-43662 Remove Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -35,6 +35,6 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.5.1
     hooks:
     - id: black

--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@
 """
 Update the Hiero export to be Tank/Shotgun aware
 """
+
 import re
 import os
 import sys

--- a/info.yml
+++ b/info.yml
@@ -243,3 +243,4 @@ description: "App that adds Flow Production Tracking awareness to Nuke Studio's 
              the Shots in Flow Production Tracking."
 
 requires_core_version: "v0.18.124"
+minimum_python_version: "3.9"

--- a/python/tk_hiero_export/sg_shot_processor.py
+++ b/python/tk_hiero_export/sg_shot_processor.py
@@ -75,9 +75,9 @@ class ShotgunShotProcessorUI(
         # This method's signature changed in NukeStudio/Hiero 10.5v1. So
         # we account for it by parsing the args.
         if self.app.get_nuke_version_tuple() >= (10, 5, 1):
-            (widget, taskUIWidget, exportItems) = args
+            widget, taskUIWidget, exportItems = args
         else:
-            (widget, exportItems, editMode) = args
+            widget, exportItems, editMode = args
 
         # create a layout with custom top and bottom widgets
         master_layout = QtGui.QHBoxLayout(widget)
@@ -91,8 +91,7 @@ class ShotgunShotProcessorUI(
         # create some helpful text
         header_text = QtGui.QLabel()
         header_text.setWordWrap(True)
-        header_text.setText(
-            """
+        header_text.setText("""
             <big>Welcome to the Flow Production Tracking Shot Exporter!</big>
             <p>When you are using the Flow Production Tracking Shot Processor, Shots and
             Sequences in Flow Production Tracking will be created based on the curent timeline.
@@ -101,8 +100,7 @@ class ShotgunShotProcessorUI(
             you use the special Flow Production Tracking Transcode plugin - all included and
             ready to go in the default preset.
             </p>
-            """
-        )
+            """)
         shotgun_layout.addWidget(header_text)
         shotgun_layout.addSpacing(8)
 
@@ -368,7 +366,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         properties = self._preset.properties().get("shotgunShotCreateProperties", {})
 
         # inject collate settings into Tasks where needed
-        (collateTracks, collateShotNames) = self._getCollateProperties()
+        collateTracks, collateShotNames = self._getCollateProperties()
         for itemPath, itemPreset in exportTemplate:
             if "collateTracks" in itemPreset.properties():
                 itemPreset.properties()["collateTracks"] = collateTracks
@@ -445,7 +443,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         for taskGroup in self._submission.children():
 
             # placeholders for the tasks we want to pre-process
-            (shot_updater_task, transcode_task) = (None, None)
+            shot_updater_task, transcode_task = (None, None)
 
             # look at all the tasks in the group and identify the shot updater
             # and transcode tasks.
@@ -483,7 +481,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         # go ahead and populate the shot updater tasks with the cut order. this
         # is used to set the cut order on the Shot as it is created/updated.
         for i in range(0, len(cut_related_tasks)):
-            (shot_updater_task, transcode_task) = cut_related_tasks[i]
+            shot_updater_task, transcode_task = cut_related_tasks[i]
 
             # Cut order is 1-based
             shot_updater_task._cut_order = i + 1
@@ -524,7 +522,7 @@ class ShotgunShotProcessor(ShotgunHieroObjectBase, FnShotProcessor.ShotProcessor
         # collate complicates cut support for hiero. For now duck out at this
         # point with a log msg. The user should be aware of this from the
         # message in the collating preset UI.
-        (collateTracks, collateShotNames) = self._getCollateProperties()
+        collateTracks, collateShotNames = self._getCollateProperties()
         if collateTracks or collateShotNames:
             self.app.log_info(
                 "Cut support is ill defined for collating in Hiero. Not "

--- a/python/tk_hiero_export/shot_updater.py
+++ b/python/tk_hiero_export/shot_updater.py
@@ -40,7 +40,7 @@ class ShotgunShotUpdater(
         The values correspond to the exported version created on disk.
         """
 
-        (head_in, tail_out) = self.collatedOutputRange(clampToSource=False)
+        head_in, tail_out = self.collatedOutputRange(clampToSource=False)
 
         handles = self._cutHandles if self._cutHandles is not None else 0
         in_handle = handles

--- a/python/tk_hiero_export/version_creator.py
+++ b/python/tk_hiero_export/version_creator.py
@@ -151,9 +151,7 @@ class ShotgunTranscodeExporter(
         set_command = nuke.SetNode(self._write_set_node_label, 0)
         script.addNode(set_command)
 
-        super(ShotgunTranscodeExporter, self).addWriteNodeToScript(
-            script, rootNode, framerate
-        )
+        super().addWriteNodeToScript(script, rootNode, framerate)
 
     def buildScript(self):
         """


### PR DESCRIPTION
## Summary

- Set `minimum_python_version: "3.9"` in `info.yml`
- Replace old-style `super(ClassName, self)` call with `super()`
- Bump pre-commit hooks and apply black formatting

## Test plan

- [ ] Pre-commit passes cleanly
- [ ] No Python 3.7 references remain (verified by automated check script)